### PR TITLE
prevent 'eval' call after closing

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ class Daemon extends EventEmitter {
   close (signal) {
     this.child.kill(signal)
     this.stdout = this.stdin = null
+    this.eval = () => {}
     clearInterval(this.keepaliveInterval)
   }
 }

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class Daemon extends EventEmitter {
   close (signal) {
     this.child.kill(signal)
     this.stdout = this.stdin = null
-    this.eval = () => {}
+    this.eval = (code, cb) => cb && cb(new Error('Daemon already closed'))
     clearInterval(this.keepaliveInterval)
   }
 }


### PR DESCRIPTION
Solves the issue that after closing the daemon sometimes asynchronous `eval` calls would throw an error as [stdin](https://github.com/mappum/electron-eval/blob/master/index.js#L58) does not exist anymore. 