### PR TITLE
Adds env variable flag, test, and updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Run code inside a hidden Electron window
 
 `electron-eval` gives you a way to access a headless browser (Chromium) from Node.js. This can be useful for testing browser-specific code, or using web APIs that are in browsers but not yet in Node (such as [WebRTC](https://github.com/mappum/electron-webrtc)).
 
+## Prerequisites
+
+To run headless mode, you'll need the `xvfb` package:
+
+	$ sudo apt-get install xvfb
+
 ## Usage
 
 `npm install electron-eval`
@@ -98,6 +104,11 @@ A handle to the Electron daemon's process (of type [child_process.ChildProcess](
 Emitted by `daemon` when the Electron window has been set up and is ready to eval code.
 #### - `error`
 Emitted by `daemon` when `daemon.eval()` evaluates code that throws an error, but no callback is provided.
+
+### Environment Variables
+
+#### `HEADLESS`
+Setting this variable to true also allows the module to go into headless mode.
 
 ## Related
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class Daemon extends EventEmitter {
     super()
     opts = opts || {}
     opts.timeout = typeof opts.timeout === 'number' ? opts.timeout : 10e3
-    if (opts.headless) {
+    if (opts.headless || process.env.HEADLESS) {
       this.xvfb = new Xvfb(opts.xvfb || {})
       this.xvfb.startSync()
     }

--- a/test.js
+++ b/test.js
@@ -90,3 +90,13 @@ test('close daemon', (t) => {
   })
   daemon.close()
 })
+
+test('xvfb has started and shutdown', (t) => {
+  daemon = electronEval({ headless: true })
+  daemon.on('ready', function () {
+    t.pass('no errors were thrown when starting Xvfb')
+    daemon.close()
+    t.pass('no errors were thrown when ending Xvfb')
+    t.end()
+  })
+})


### PR DESCRIPTION
As suggested in https://github.com/mappum/electron-eval/pull/11. I also added a test to check that the daemon successfully runs on headless mode without error, and added updated documentation which includes installing `xvfb` as a prereq.