### PR TITLE
Only run last test if HEADLESS variable is set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
       - g++-multilib
       - xvfb
 install:
+  - export HEADLESS=true
   - rm -rf ~/.nvm
   - git clone https://github.com/creationix/nvm.git ~/.nvm
   - source ~/.nvm/nvm.sh

--- a/test.js
+++ b/test.js
@@ -91,12 +91,14 @@ test('close daemon', (t) => {
   daemon.close()
 })
 
-test('xvfb has started and shutdown', (t) => {
-  daemon = electronEval({ headless: true })
-  daemon.on('ready', function () {
-    t.pass('no errors were thrown when starting Xvfb')
-    daemon.close()
-    t.pass('no errors were thrown when ending Xvfb')
-    t.end()
+if (process.env.HEADLESS) {
+  test('xvfb has started and shutdown', (t) => {
+    daemon = electronEval()
+    daemon.on('ready', function () {
+      t.pass('no errors were thrown when starting Xvfb')
+      daemon.close()
+      t.pass('no errors were thrown when ending Xvfb')
+      t.end()
+    })
   })
-})
+}


### PR DESCRIPTION
This PR should address the latest issue with tests failing on non-headless environments by only running the test if the `HEADLESS` variable is set.