### PR TITLE
Add an option to eval code in main process

### DIFF
--- a/app/daemon.js
+++ b/app/daemon.js
@@ -24,7 +24,19 @@ function main (opts) {
   stdin.on('data', function (message) {
     resetTimeout()
     if (typeof message !== 'object') return
-    window.webContents.send('data', message)
+    if (message.evalInRenderer) {
+      delete message.evalInRenderer
+      window.webContents.send('data', message)
+    } else {
+      var res
+      var err
+      try {
+        res = eval(message.code)
+      } catch(e) {
+        err = e.message
+      }
+      stdout.write([ message.id, { res: res, err: err }])
+    }
   })
 
   ipc.on('data', function (e, data) {

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ class Daemon extends EventEmitter {
   }
 
   eval (code, evalInRenderer, cb) {
-    if (!cb) cb = evalInRenderer
+    if (typeof evalInRenderer === 'function') cb = evalInRenderer
     evalInRenderer = evalInRenderer !== false
     var id = (i++).toString(36)
     this.once(id, (res) => {

--- a/test.js
+++ b/test.js
@@ -54,6 +54,24 @@ test('erroring code with no callback', (t) => {
   daemon.eval('foo()')
 })
 
+test('eval in main process', (t) => {
+  daemon.eval('!!window.webContents', false, (err, res) => {
+    t.pass('callback called')
+    t.error(err, 'no error')
+    t.equal(res, true, 'correct response value')
+    t.end()
+  })
+})
+
+test('eval in renderer', (t) => {
+  daemon.eval('!!window.webContents', true, (err, res) => {
+    t.pass('callback called')
+    t.error(err, 'no error')
+    t.equal(res, false, 'correct response value')
+    t.end()
+  })
+})
+
 test('close daemon', (t) => {
   daemon.child.once('exit', () => {
     t.pass('daemon process exited')

--- a/test.js
+++ b/test.js
@@ -63,8 +63,13 @@ test('eval in main process', (t) => {
   })
 })
 
+test('eval with no callback', (t) => {
+  daemon.eval('!!window.webContents', true)
+  t.end()
+})
+
 test('eval in renderer', (t) => {
-  daemon.eval('!!window.webContents', true, (err, res) => {
+  daemon.eval('!!window.webContents', (err, res) => {
     t.pass('callback called')
     t.error(err, 'no error')
     t.equal(res, false, 'correct response value')


### PR DESCRIPTION
Like I said in #44, it could be handy to be able to run code in the main process to use the electron API for example to set the proxy settings.

Added a param to the eval function do do just that. 