### PR TITLE
Fix "Object has been destroyed" exception

### DIFF
--- a/app/daemon.js
+++ b/app/daemon.js
@@ -47,6 +47,10 @@ function createWindow () {
     process.on('message', onMessage)
     process.send('ready')
   })
+  window.once('close', function () {
+    process.removeListener('message', onMessage)
+    window = null
+  })
 }
 
 function onMessage (message) {
@@ -62,7 +66,7 @@ function onMessage (message) {
     }
     process.send([ message.id, { res: res, err: err } ])
   } else {
-    window.webContents.send('data', message)
+    if (window) window.webContents.send('data', message)
   }
 }
 


### PR DESCRIPTION
This can happen if onMessage() events get sent after the window is
destroyed.

Noticed it happening in `webtorrent-hybrid`. When it happened, the exception window was showing and hiding so fast that it was impossible to read. So I captured a video with Quicktime and froze this frame:

<img width="564" alt="screen shot 2016-10-04 at 12 18 08 am" src="https://cloud.githubusercontent.com/assets/121766/19065428/5257da14-89c8-11e6-8896-cf4a2fdb60fb.png">

Intense detective work, but you can see the error is from `daemon.js:65` :)
